### PR TITLE
Limit ldap queries to only return people.

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
@@ -68,7 +68,7 @@ class DirectoryEntityDAO {
      */
     public List<DirectoryEntity> getBySearchQuery(String searchQuery)
             throws LdapException {
-        String filter = '(&'
+        String filter = '(&(objectclass=person)(&'
         for (String searchTerm : split(sanitize(searchQuery))) {
             if (searchTerm) {
                 filter += '(|' + '(cn=*' + searchTerm + '*)' +
@@ -76,7 +76,7 @@ class DirectoryEntityDAO {
                                '(mail=*' + searchTerm + '*)' + ')'
             }
         }
-        filter += ')'
+        filter += '))'
         searchLDAP(filter)
     }
 


### PR DESCRIPTION
CO-427

Add objectclass=person to the ldap filter to filter out non-people.

The old directory did this. We should too just to be safe.
(Although, not surprisingly, everybody in ou=People currently has
objectclass=person so this is probably more paranoid than necessary)
