### PR TITLE
return bad request when ldap exception is thrown

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityResource.groovy
@@ -74,7 +74,7 @@ class DirectoryEntityResource extends Resource {
                 responseBuilder = ok(resultObject)
             } catch (LdapException ldapException) {
                 logger.error("Ldap Exception thrown when getting by search query", ldapException)
-                responseBuilder = internalServerError(ldapException.message)
+                responseBuilder = badRequest(ldapException.message)
             }
         }
         responseBuilder.build()


### PR DESCRIPTION
it makes more sense to throw a 400 error rather than 500 for caught exceptions. This will help us narrow down 500 responses in appdynamics to uncaught/unexpected errors