### PR TITLE
remove relationships

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -150,8 +150,6 @@ definitions:
         $ref: "#/definitions/Attributes"
       links:
         $ref: "#/definitions/ResourceLinks"
-      relationships:
-        $ref: "#/definitions/Relationships"
   Attributes:
     properties:
       firstName:
@@ -188,14 +186,6 @@ definitions:
       osuuid:
         type: integer
         format: int64
-  Relationships:
-    properties:
-      academic:
-        properties:
-          links:
-            properties:
-              related:
-                type: string
   ResourceLinks:
     properties:
       self:


### PR DESCRIPTION
This block was added for the digital measures ticket. We can always add it back, but in an effort to make the swagger reflect what the API produces, let's remove it for now.