### PR TITLE
Refactor ldap connection pool logic out of the DirectoryDAO

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryApplication.groovy
@@ -33,7 +33,7 @@ class DirectoryApplication extends Application<DirectoryApplicationConfiguration
         environment.jersey().register(new DirectoryEntityResource(DIRECTORYENTITYDAO, endpointUri))
     }
 
-    private static configureLdapPool(Map<String,Object> ldapConfiguration) {
+    private static PooledConnectionFactory configureLdapPool(Map<String,Object> ldapConfiguration) {
         def ldapURL = (String) ldapConfiguration.get('url')
         DefaultConnectionFactory defaultConnectionFactory = new DefaultConnectionFactory(ldapURL)
 

--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryApplication.groovy
@@ -21,7 +21,8 @@ class DirectoryApplication extends Application<DirectoryApplicationConfiguration
     public void run(DirectoryApplicationConfiguration configuration, Environment environment) {
         this.setup(configuration, environment)
 
-        def ldapConnectionPool = configureLdapPool(configuration.ldapConfiguration)
+        PooledConnectionFactory ldapConnectionPool = configureLdapPool(
+                configuration.ldapConfiguration)
 
         final DirectoryEntityDAO DIRECTORYENTITYDAO = new DirectoryEntityDAO(
                 configuration.ldapConfiguration,

--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryApplication.groovy
@@ -34,7 +34,7 @@ class DirectoryApplication extends Application<DirectoryApplicationConfiguration
     }
 
     private static PooledConnectionFactory configureLdapPool(Map<String,Object> ldapConfiguration) {
-        def ldapURL = (String) ldapConfiguration.get('url')
+        def ldapURL = (String)ldapConfiguration.get('url')
         DefaultConnectionFactory defaultConnectionFactory = new DefaultConnectionFactory(ldapURL)
 
         PoolConfig poolConfig = new PoolConfig(

--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
@@ -15,7 +15,6 @@ import java.util.regex.Pattern
  * Directory entity data access object.
  */
 class DirectoryEntityDAO {
-    private final String LDAP_URL
     private final String BASE_DN
     private final PooledConnectionFactory pooledConnectionFactory
     private static final Pattern illegalCharacterPattern = Pattern.compile(
@@ -71,7 +70,6 @@ class DirectoryEntityDAO {
     public DirectoryEntityDAO(Map<String,Object> ldapConfiguration,
                               PooledConnectionFactory ldapConnectionPool) {
 
-        LDAP_URL = (String)ldapConfiguration.get('url')
         BASE_DN = (String)ldapConfiguration.get('base')
         pooledConnectionFactory = ldapConnectionPool
     }

--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
@@ -1,6 +1,5 @@
 package edu.oregonstate.mist.directoryapi
 
-import org.ldaptive.DefaultConnectionFactory
 import org.ldaptive.Connection
 import org.ldaptive.LdapEntry
 import org.ldaptive.LdapException
@@ -10,8 +9,6 @@ import org.ldaptive.SearchOperation
 import org.ldaptive.SearchRequest
 import org.ldaptive.SearchResult
 import org.ldaptive.pool.PooledConnectionFactory
-import org.ldaptive.pool.SoftLimitConnectionPool
-import org.ldaptive.pool.PoolConfig
 import java.util.regex.Pattern
 
 /**

--- a/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/directoryapi/DirectoryEntityDAO.groovy
@@ -71,24 +71,12 @@ class DirectoryEntityDAO {
      *
      * @param ldapConfiguration
      */
-    public DirectoryEntityDAO(Map<String,Object> ldapConfiguration) {
+    public DirectoryEntityDAO(Map<String,Object> ldapConfiguration,
+                              PooledConnectionFactory ldapConnectionPool) {
+
         LDAP_URL = (String)ldapConfiguration.get('url')
         BASE_DN = (String)ldapConfiguration.get('base')
-        DefaultConnectionFactory defaultConnectionFactory = new DefaultConnectionFactory(LDAP_URL)
-        PoolConfig poolConfig = new PoolConfig(
-                maxPoolSize: (int)ldapConfiguration.get('maxPoolSize'),
-                minPoolSize: (int)ldapConfiguration.get('minPoolSize'),
-                validateOnCheckIn: (boolean)ldapConfiguration.get('validateOnCheckIn'),
-                validateOnCheckOut: (boolean)ldapConfiguration.get('validateOnCheckOut'),
-                validatePeriod: (long)ldapConfiguration.get('validatePeriod'),
-                validatePeriodically: (boolean)ldapConfiguration.get('validatePeriodically')
-        )
-        SoftLimitConnectionPool pool = new SoftLimitConnectionPool(
-                poolConfig, defaultConnectionFactory
-        )
-
-        pool.initialize()
-        pooledConnectionFactory = new PooledConnectionFactory(pool)
+        pooledConnectionFactory = ldapConnectionPool
     }
 
     /**


### PR DESCRIPTION
CO-294

Moves the ldap connection logic out of the DirectoryDAO as it shouldn't be creating those connections.