### PR TITLE
(CO-1634) Removing extra parentheses causing the 'invalid nested parens' error

### DIFF
--- a/src/api/v2/db/ldap/directory-dao.js
+++ b/src/api/v2/db/ldap/directory-dao.js
@@ -53,7 +53,7 @@ const mapQuery = (endpointQuery) => {
       case 'alternatePhoneNumber':
       case 'faxNumber':
       case 'officeAddress': {
-        return `(${ldapKey}=*${value}*)`;
+        return `${ldapKey}=*${value}*`;
       }
       case 'phoneNumber': {
         return `|(${ldapKey}=*${value}*)(${keyMap.alternatePhoneNumber}=*${value}*)`


### PR DESCRIPTION
This fix now has the faxNumber, officeAddress, alternatePhoneNumber, and officePhoneNumber params working as intended. I tested using each param by themselves and in combination with other params. Let me know if this is good to merge.